### PR TITLE
Re-initialize error in Chat

### DIFF
--- a/app/state/hooks/use-chat.tsx
+++ b/app/state/hooks/use-chat.tsx
@@ -30,6 +30,7 @@ export const useChat = () => {
                 .then((messages: Message[]) => {
                     setMessages(messages);
                 })
+                .then(() => setError(null))
                 .catch(err => setError(err))
                 .finally(() => setIsLoading(false));
         }
@@ -85,6 +86,7 @@ export const useChat = () => {
     const resetThread = () => {
         setMessages([]);
         setData({});
+        setError(null);
     };
 
     return {


### PR DESCRIPTION
Error messages persist in state after

* pressing "Reset Thread"
* subsequent successful queries

This commit addresses both cases.