### PR TITLE
fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Welcome to the LLM Map Visualization project! This is a proof-of-concept prototy
 - **Mapbox and DeckGL**: WebGL-powered frameworks for mapping and data analysis
 - **Neon**: Serverless Postgres database to store saved map visualizations
 - **Pinecone**: Vector database for similarity search
-- **Claude**: Anthropic's large language model (using both haiku for simple queries and sonnet 3.5 for more complex reasoning)
+- **Claude**: Anthropic's large language model (using both Haiku for simple queries and Sonnet 3.5 for more complex reasoning)
 - **Voyage**: Embeddings ABI
 - **Clerk**: User authentication management
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -52,7 +52,7 @@ function SplashPage() {
                             </h1>
                             <p className="mt-6 text-lg leading-8 text-gray-600">
                                 Powered by Claude AI, this tool creates a unique data visualization
-                                experience allowing you generate complex maps from data in seconds
+                                experience allowing you to generate complex maps from data in seconds
                                 both with voice and text queries.
                             </p>
                             <div className="mt-10 flex items-center justify-center gap-x-6">


### PR DESCRIPTION
* Add "to": "allowing you generate complex maps" -> "allowing you to generate complex maps"
* Capitalizes Claude products in README.md

![To](https://github.com/user-attachments/assets/b15538e0-61bd-439a-83b0-7edcc074e7c0)

