### PR TITLE
add mapbox attribution

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -14,6 +14,7 @@ import { neon } from '@neondatabase/serverless';
 import { formatValue, getBoundingBox, interpolateColor } from '@/lib/utils';
 import { useAuth } from '@clerk/nextjs';
 import Link from 'next/link';
+import { MapboxAttribution } from './MapboxAttribution';
 
 type Tooltip = {
     name: string;
@@ -279,6 +280,7 @@ export const Map = () => {
                     {renderButton()}
                 </div>
             )}
+            <MapboxAttribution/>
             <MapLegend />
             {tooltip?.value && (
                 <div

--- a/app/components/MapboxAttribution.tsx
+++ b/app/components/MapboxAttribution.tsx
@@ -1,0 +1,14 @@
+export function MapboxAttribution() {
+    return (
+        <div className="absolute bottom-1 left-1 z-50 p-2">
+            <a
+                href="https://www.mapbox.com/about/maps/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-gray-500 block"
+            >
+                © Mapbox
+            </a>
+        </div>
+    );
+}


### PR DESCRIPTION
Adds [Mapbox attribution](https://docs.mapbox.com/help/dive-deeper/attribution/) in lower-left of Map component.

![Screenshot 2024-07-15 at 4 11 41 PM](https://github.com/user-attachments/assets/bb520435-9e61-4236-a5c0-d1e6d0cc5de7)
